### PR TITLE
1.3 Non-recommendation method was corrected.

### DIFF
--- a/Source/Behavior.js
+++ b/Source/Behavior.js
@@ -123,7 +123,7 @@ provides: [Behavior]
 						} else if(config.initializer){
 							this._customInit(element, filter, force);
 						} else {
-							plugins.extend(this.applyFilter(element, filter, force, true));
+							plugins.append(this.applyFilter(element, filter, force, true));
 						}
 					}
 				}, this);


### PR DESCRIPTION
Because **Array.extend** was non-recommendation by 1.3, it changed to **Array.append**.
