### PR TITLE
Fix Event.Mock for core 1.4 nocompat

### DIFF
--- a/Source/Event.Mock.js
+++ b/Source/Event.Mock.js
@@ -16,7 +16,8 @@ provides: [Event.Mock]
 ...
 */
 
-(function($,window,undef){
+(function(window){
+window.Event = window.Event || window.DOMEvent; //for 1.4 nocompat
 
 /**
  * creates a Mock event to be used with fire event
@@ -48,4 +49,4 @@ Event.Mock = function(target,type){
 	return e;
 };
 
-})(document.id,window);
+})(window);


### PR DESCRIPTION
[Relevant core lines](https://github.com/mootools/mootools-core/blob/ceca0cd9c3a6879c42894741134b780439bfda99/Source/Types/DOMEvent.js#L116-119)

Breaks ie7
